### PR TITLE
Naming changes for consistency and ability to publish a NATS::Message

### DIFF
--- a/src/nats.cr
+++ b/src/nats.cr
@@ -146,7 +146,7 @@ module NATS
       uri : URI,
       ping_interval = 2.minutes,
       max_pings_out = 2,
-      nkeys_file : String? = nil,
+      nkeys_file : String? = nil
     )
       new([uri], ping_interval: ping_interval, max_pings_out: max_pings_out, nkeys_file: nkeys_file)
     end
@@ -164,7 +164,7 @@ module NATS
       @servers : Array(URI),
       @ping_interval : Time::Span = 2.minutes,
       @max_pings_out = 2,
-      @nkeys_file : String? = nil,
+      @nkeys_file : String? = nil
     )
       uri = @servers.sample
       @ping_count = Atomic.new(0)
@@ -228,7 +228,7 @@ module NATS
         nkey = NKeys.new(File.read(nkeys_file.strip))
 
         connect = connect.merge({
-          sig: Base64.urlsafe_encode(nkey.keypair.sign(nonce), padding: false),
+          sig:  Base64.urlsafe_encode(nkey.keypair.sign(nonce), padding: false),
           nkey: Base32.encode(nkey.keypair.public_key, pad: false),
         })
       end
@@ -286,7 +286,7 @@ module NATS
     #
     # nats = NATS::Client.new
     # nats.subscribe "orders.created" do |msg|
-    #   order = Order.from_json(String.new(msg.body))
+    #   order = Order.from_json(String.new(msg.payload))
     #
     #   # ...
     # end
@@ -360,12 +360,12 @@ module NATS
     #   response.status = :service_unavailable
     # end
     # ```
-    def request(subject : String, message : Data = "", timeout : Time::Span = 2.seconds, headers : Headers? = nil) : Message?
+    def request(subject : String, payload : Data = "", timeout : Time::Span = 2.seconds, headers : Headers? = nil) : Message?
       channel = Channel(Message).new(1)
       inbox = NUID.next
       key = "#{@inbox_prefix}.#{inbox}"
       @inbox_handlers[key] = ->(msg : Message) { channel.send msg }
-      publish subject, message, reply_to: key, headers: headers
+      publish subject, payload, reply_to: key, headers: headers
 
       # TODO: Track how often we're making requests. If we're making requests
       # often enough, we don't need to flush the buffer after every request, and
@@ -391,14 +391,14 @@ module NATS
     # Make an asynchronous request to subscribers of the given `subject`, not
     # waiting for a response. The first message to come back will be passed to
     # the block.
-    def request(subject : String, message : Data = "", timeout = 2.seconds, &block : Message ->) : Nil
+    def request(subject : String, payload : Data = "", timeout = 2.seconds, &block : Message ->) : Nil
       inbox = NUID.next
       key = "#{@inbox_prefix}.#{inbox}"
       @inbox_handlers[key] = ->(msg : Message) do
         block.call msg
         @inbox_handlers.delete key
       end
-      publish subject, message, reply_to: key
+      publish subject, payload, reply_to: key
 
       spawn remove_key(key, after: timeout)
     end
@@ -408,7 +408,7 @@ module NATS
       @inbox_handlers.delete key
     end
 
-    # Send the given `body` to the `msg`'s `reply_to` subject, often used in a
+    # Send the given `payload` to the `msg`'s `reply_to` subject, often used in a
     # request/reply messaging model.
     #
     # ```
@@ -422,15 +422,15 @@ module NATS
     #   end
     # end
     # ```
-    def reply(msg : Message, body : Data) : Nil
+    def reply(msg : Message, payload : Data) : Nil
       if subject = msg.reply_to
-        publish subject, body
+        publish subject, payload
       else
         raise NotAReply.new("Cannot reply to a message that has no return address", msg)
       end
     end
 
-    # Publish the given message body (either `Bytes` for binary data or `String` for text) on the given NATS subject, optionally supplying a `reply_to` subject (if expecting a reply or to notify the receiver where to send updates) and any `headers`.
+    # Publish the given message payload (either `Bytes` for binary data or `String` for text) on the given NATS subject, optionally supplying a `reply_to` subject (if expecting a reply or to notify the receiver where to send updates) and any `headers`.
     #
     # ```
     # # Send an empty message to a subject
@@ -444,7 +444,7 @@ module NATS
     # reply_subject = "replies.orders.list.customer.123"
     # orders = [] of Order
     # nats.subscribe reply_subject do |msg|
-    #   case result = (Order | Complete).from_json(String.new(msg.body))
+    #   case result = (Order | Complete).from_json(String.new(msg.payload))
     #   in Order
     #     orders << result
     #   in Complete
@@ -463,12 +463,12 @@ module NATS
     #   "Nats-Msg-Id" => "order-submitted-#{order.id}-#{order.updated_at.to_json}",
     # }
     # ```
-    def publish(subject : String, message : Data = Bytes.empty, reply_to : String? = nil, headers : Message::Headers? = nil) : Nil
+    def publish(subject : String, payload : Data = Bytes.empty, reply_to : String? = nil, headers : Message::Headers? = nil) : Nil
       if message.bytesize > MAX_PUBLISH_SIZE
-        raise Error.new("Attempted to publish message of size #{message.bytesize}. Cannot publish messages larger than #{MAX_PUBLISH_SIZE}.")
+        raise Error.new("Attempted to publish message of size #{payload.bytesize}. Cannot publish messages larger than #{MAX_PUBLISH_SIZE}.")
       end
 
-      LOG.debug { "Publishing #{message.bytesize} bytes to #{subject.inspect}, reply_to: #{reply_to.inspect}, headers: #{headers.inspect}" }
+      LOG.debug { "Publishing #{payload.bytesize} bytes to #{subject.inspect}, reply_to: #{reply_to.inspect}, headers: #{headers.inspect}" }
       write do
         if headers
           @io << "HPUB "
@@ -488,19 +488,23 @@ module NATS
             bytes += key.bytesize + value.bytesize + 4 # 2 extra bytes for ": " and 2 for CR+LF
           end
           @io << ' ' << header_length
-          @io << ' ' << header_length + message.bytesize << "\r\n"
+          @io << ' ' << header_length + payload.bytesize << "\r\n"
           @io << nats_header_preamble
           headers.each do |key, value|
             @io << key << ": " << value << "\r\n"
           end
           @io << "\r\n"
         else
-          @io << ' ' << message.bytesize << "\r\n"
+          @io << ' ' << payload.bytesize << "\r\n"
         end
 
-        @io.write message.to_slice
+        @io.write payload.to_slice
         @io << "\r\n"
       end
+    end
+
+    def publish(message : Message) : Nil
+      publish message.subject, message.payload, message.reply_to, message.headers
     end
 
     # Flush the client's output buffer over the wire
@@ -640,12 +644,12 @@ module NATS
             raise Error.new("Invalid message declaration: #{line.inspect}")
           end
 
-          body = Bytes.new(bytesize)
-          @socket.read_fully?(body) || raise Error.new("Unexpected EOF")
+          payload = Bytes.new(bytesize)
+          @socket.read_fully?(payload) || raise Error.new("Unexpected EOF")
           @socket.skip 2 # CRLF
 
           if subscription = @subscriptions[sid]?
-            subscription.send Message.new(subject, body, reply_to: reply_to, headers: headers) do |ex|
+            subscription.send Message.new(subject, payload, reply_to: reply_to, headers: headers) do |ex|
               LOG.debug { "Error occurred in handling subscription #{sid}: #{ex}" }
               @on_error.call ex
             end
@@ -809,18 +813,23 @@ module NATS
 
   struct Message
     getter subject : String
-    getter body : Bytes
+    getter payload : Bytes
     getter reply_to : String?
     getter headers : Headers?
 
     alias Headers = Hash(String, String)
 
-    def initialize(@subject, @body, @reply_to = nil, @headers = nil)
+    def initialize(@subject, @payload, @reply_to = nil, @headers = nil)
     end
 
-    @[Deprecated("Instantiating a new IO::Memory for each message made them heavier than intended, so we're now recommending using `String.new(msg.body)`")]
+    @[Deprecated("Instantiating a new IO::Memory for each message made them heavier than intended, so we're now recommending using `String.new(msg.payload)`")]
     def body_io
       @body_io ||= IO::Memory.new(@body)
+    end
+
+    @[Deprecated("`body` deprecated in favor of `payload` to conform with NATS protocol nomenclature")]
+    def body
+      @payload
     end
   end
 


### PR DESCRIPTION
There were interchangeable uses of "message", "body", and "data" referring
to the message payload data. This change conforms to the [NATS protocol](https://docs.nats.io/reference/reference-protocols/nats-protocol#msg)
which uses "message" as the encompassing message (headers + payload), and
"payload" as the primary data.

Also adds another `publish` method that takes a `NATS::Message` struct and
pipes it to the existing `publish` method