### PR TITLE
Add an EventParser for inbound loop

### DIFF
--- a/spec/event_parser_spec.cr
+++ b/spec/event_parser_spec.cr
@@ -1,0 +1,220 @@
+require "./spec_helper"
+require "../src/event_parser"
+
+describe NATS::EventParser do
+  it "parses a message without headers" do
+    io = IO::Memory.new(<<-EOF)
+      MSG subject sid reply_to 11\r
+      hello world\r
+
+      EOF
+    event = NATS::EventParser.new(io).call.should be_a NATS::Protocol::MessageEvent
+
+    msg = event.message
+    msg.subject.should eq "subject"
+    msg.reply_to.should eq "reply_to"
+    msg.data_string.should eq "hello world"
+    event.sid.should eq "sid"
+  end
+
+  it "parses a message with headers" do
+    io = IO::Memory.new(<<-EOF)
+      HMSG subject sid reply_to 27 38\r
+      NATS/1.0\r
+      Header: Value\r
+      \r
+      hello world\r
+
+      EOF
+    event = NATS::EventParser.new(io).call.should be_a NATS::Protocol::MessageEvent
+
+    msg = event.message
+    msg.subject.should eq "subject"
+    msg.reply_to.should eq "reply_to"
+    msg.data_string.should eq "hello world"
+    msg.headers.should eq NATS::Headers{"Header" => "Value"}
+    event.sid.should eq "sid"
+  end
+
+  it "parses a message with no reply_to" do
+    io = IO::Memory.new(<<-EOF)
+      MSG subject sid 11\r
+      hello world\r
+
+      EOF
+    event = NATS::EventParser.new(io).call.should be_a NATS::Protocol::MessageEvent
+
+    msg = event.message
+    msg.subject.should eq "subject"
+    msg.reply_to.should be_nil
+    msg.data_string.should eq "hello world"
+    event.sid.should eq "sid"
+  end
+
+  it "parses a message with headers and no reply_to" do
+    io = IO::Memory.new(<<-EOF)
+      HMSG subject sid 27 38\r
+      NATS/1.0\r
+      Header: Value\r
+      \r
+      hello world\r
+
+      EOF
+    event = NATS::EventParser.new(io).call.should be_a NATS::Protocol::MessageEvent
+
+    msg = event.message
+    msg.subject.should eq "subject"
+    msg.reply_to.should be_nil
+    msg.data_string.should eq "hello world"
+    msg.headers.should eq NATS::Headers{"Header" => "Value"}
+    event.sid.should eq "sid"
+  end
+
+  it "parses a message whose header block holds no headers" do
+    io = IO::Memory.new(<<-EOF)
+      HMSG subject sid reply_to 12 23\r
+      NATS/1.0\r
+      \r
+      hello world\r
+
+      EOF
+    event = NATS::EventParser.new(io).call.should be_a NATS::Protocol::MessageEvent
+
+    msg = event.message
+    msg.data_string.should eq "hello world"
+    msg.headers.should be_empty
+    msg.headers["Status"]?.should be_nil
+  end
+
+  it "parses a message with several headers, including repeated ones" do
+    io = IO::Memory.new(<<-EOF)
+      HMSG subject sid reply_to 43 54\r
+      NATS/1.0\r
+      First: 1\r
+      Second: 2\r
+      First: 3\r
+      \r
+      hello world\r
+
+      EOF
+    event = NATS::EventParser.new(io).call.should be_a NATS::Protocol::MessageEvent
+
+    msg = event.message
+    msg.data_string.should eq "hello world"
+    msg.headers.get("First").should eq %w[1 3]
+    msg.headers.get("Second").should eq %w[2]
+  end
+
+  it "exposes the status of a no-responders reply" do
+    io = IO::Memory.new(<<-EOF)
+      HMSG _INBOX.wLQZbaDX 3 30 30\r
+      NATS/1.0 503 No Responders\r
+      \r
+      \r
+
+      EOF
+    event = NATS::EventParser.new(io).call.should be_a NATS::Protocol::MessageEvent
+
+    msg = event.message
+    msg.subject.should eq "_INBOX.wLQZbaDX"
+    msg.data_string.should eq ""
+    msg.headers["Status"].should eq "503 No Responders"
+    event.sid.should eq "3"
+  end
+
+  it "exposes a status with no description" do
+    io = IO::Memory.new(<<-EOF)
+      HMSG _INBOX.wLQZbaDX 3 16 16\r
+      NATS/1.0 100\r
+      \r
+      \r
+
+      EOF
+    event = NATS::EventParser.new(io).call.should be_a NATS::Protocol::MessageEvent
+
+    event.message.headers["Status"].should eq "100"
+  end
+
+  it "consumes exactly one event, leaving the next one on the IO" do
+    io = IO::Memory.new(<<-EOF)
+      MSG subject sid 5\r
+      first\r
+      HMSG subject sid reply_to 27 33\r
+      NATS/1.0\r
+      Header: Value\r
+      \r
+      second\r
+
+      EOF
+    parser = NATS::EventParser.new(io)
+
+    first = parser.call.should(be_a NATS::Protocol::MessageEvent).message
+    first.data_string.should eq "first"
+    first.headers.should be_empty
+
+    second = parser.call.should(be_a NATS::Protocol::MessageEvent).message
+    second.data_string.should eq "second"
+    second.headers.should eq NATS::Headers{"Header" => "Value"}
+
+    io.pos.should eq io.size
+  end
+
+  it "parses PING and PONG" do
+    io = IO::Memory.new("PING\r\nPONG\r\n")
+    parser = NATS::EventParser.new(io)
+
+    parser.call.should be_a NATS::Protocol::PingEvent
+    parser.call.should be_a NATS::Protocol::PongEvent
+    io.pos.should eq io.size
+  end
+
+  it "parses +OK" do
+    io = IO::Memory.new("+OK\r\n")
+
+    NATS::EventParser.new(io).call.should be_a NATS::Protocol::OKEvent
+  end
+
+  it "parses INFO" do
+    io = IO::Memory.new(<<-EOF)
+      INFO {"server_id":"NABC","server_name":"nats-1","version":"2.10.7","go":"go1.21.4","host":"0.0.0.0","port":4222,"headers":true,"max_payload":1048576,"proto":1,"connect_urls":["nats-2:4222","nats-3:4222"]}\r
+
+      EOF
+    event = NATS::EventParser.new(io).call.should be_a NATS::Protocol::InfoEvent
+
+    event.server_info.server_name.should eq "nats-1"
+    event.server_info.max_payload.should eq 1_048_576
+    event.server_info.connect_urls.should eq %w[nats-2:4222 nats-3:4222]
+  end
+
+  it "parses -ERR" do
+    io = IO::Memory.new("-ERR 'Authorization Violation'\r\n")
+    event = NATS::EventParser.new(io).call.should be_a NATS::Protocol::ErrorEvent
+
+    event.error.message.should eq "-ERR 'Authorization Violation'"
+  end
+
+  it "reports commands it doesn't recognize" do
+    {"WAT is this\r\n", "PINGER\r\n", "+NOPE\r\n", "INFORMAL\r\n"}.each do |line|
+      event = NATS::EventParser.new(IO::Memory.new(line)).call
+        .should be_a NATS::Protocol::UnknownEvent
+
+      event.error.should be_a NATS::UnknownCommand
+      event.error.message.should eq line.chomp
+    end
+  end
+
+  it "consumes exactly one control line, leaving the next event on the IO" do
+    io = IO::Memory.new(<<-EOF)
+      PING\r
+      MSG subject sid 11\r
+      hello world\r
+
+      EOF
+    parser = NATS::EventParser.new(io)
+
+    parser.call.should be_a NATS::Protocol::PingEvent
+    parser.call.should(be_a NATS::Protocol::MessageEvent)
+      .message.data_string.should eq "hello world"
+    io.pos.should eq io.size
+  end
+end

--- a/src/error.cr
+++ b/src/error.cr
@@ -2,4 +2,8 @@ module NATS
   # Generic error
   class Error < ::Exception
   end
+
+  # Raised when the server sends a protocol event this client doesn't recognize.
+  class UnknownCommand < Error
+  end
 end

--- a/src/event_parser.cr
+++ b/src/event_parser.cr
@@ -1,0 +1,355 @@
+require "string_pool"
+
+require "./log"
+require "./error"
+require "./headers"
+require "./message"
+require "./server_info"
+
+module NATS
+  # :nodoc:
+  module Protocol
+    abstract struct Event
+      getter type : Type
+
+      def initialize(@type)
+      end
+
+      enum Type
+        Message
+        OK
+        Ping
+        Pong
+        Info
+        Error
+        Unknown
+      end
+    end
+
+    struct MessageEvent < Event
+      getter! message : Message
+      getter! sid : String
+
+      def initialize(@message, @sid)
+        super :message
+      end
+    end
+
+    struct OKEvent < Event
+      def initialize
+        super :ok
+      end
+    end
+
+    struct PingEvent < Event
+      def initialize
+        super :ping
+      end
+    end
+
+    struct PongEvent < Event
+      def initialize
+        super :pong
+      end
+    end
+
+    struct InfoEvent < Event
+      getter server_info : ServerInfo
+
+      def initialize(@server_info)
+        super :info
+      end
+    end
+
+    struct ErrorEvent < Event
+      getter error : Exception
+
+      def initialize(@error)
+        super :error
+      end
+    end
+
+    struct UnknownEvent < Event
+      getter error : Exception
+
+      def initialize(@error)
+        super :unknown
+      end
+    end
+  end
+
+  # :nodoc:
+  struct EventParser
+    @io : IO
+
+    STRING_POOL       = StringPool.new
+    STRING_POOL_MUTEX = Mutex.new
+
+    private LINE_BUFFER_SIZE = 4096
+    private HEADER_PREAMBLE  = "NATS/1.0"
+
+    # `#call` consumes the first byte of the line to tell messages apart from
+    # everything else, so these are the *remainders* of each control line.
+    private PING_REST = "ING".to_slice
+    private PONG_REST = "ONG".to_slice
+    private OK_REST   = "OK".to_slice
+    private INFO_REST = "NFO ".to_slice
+    private ERR_REST  = "ERR ".to_slice
+
+    def initialize(@io)
+    end
+
+    def call : Protocol::Event
+      buffer = uninitialized UInt8[LINE_BUFFER_SIZE]
+      bytes = buffer.to_slice
+
+      case first = @io.read_byte
+      when nil
+        raise IO::EOFError.new
+      when 'M'.ord # MSG
+        @io.skip 2 # "SG"
+        message, sid = parse_message bytes, headers: false
+        Protocol::MessageEvent.new(message: message, sid: sid)
+      when 'H'.ord # HMSG
+        @io.skip 3 # "MSG"
+        message, sid = parse_message bytes, headers: true
+        Protocol::MessageEvent.new(message: message, sid: sid)
+      else
+        parse_control first, read_line(bytes)
+      end
+    end
+
+    # Every event that isn't a message occupies a single line: `PING`, `PONG`,
+    # `+OK`, `INFO {…}`, or `-ERR …`. *first* is the byte `#call` consumed to
+    # work out which one it was, *rest* is the remainder of that line.
+    private def parse_control(first : UInt8, rest : Bytes) : Protocol::Event
+      case first
+      when 'P'.ord
+        case rest
+        when PING_REST then return Protocol::PingEvent.new
+        when PONG_REST then return Protocol::PongEvent.new
+        end
+      when '+'.ord
+        return Protocol::OKEvent.new if rest == OK_REST
+      when 'I'.ord
+        if starts_with? rest, INFO_REST
+          json = String.new(rest[INFO_REST.size..])
+          return Protocol::InfoEvent.new(ServerInfo.from_json(json))
+        end
+      when '-'.ord
+        if starts_with? rest, ERR_REST
+          return Protocol::ErrorEvent.new(Error.new("-#{String.new(rest)}"))
+        end
+      end
+
+      line = "#{first.unsafe_chr}#{String.new(rest)}"
+      Protocol::UnknownEvent.new(UnknownCommand.new(line))
+    end
+
+    private def starts_with?(bytes : Bytes, prefix : Bytes) : Bool
+      bytes.size >= prefix.size && bytes[0, prefix.size] == prefix
+    end
+
+    # An `MSG` event from the server looks like this (brackets imply optional):
+    #
+    #     MSG my-subject my-sid [my-reply-to] payload_size
+    #     My payload goes here
+    #
+    # An `HMSG` event carries a block of headers ahead of the payload:
+    #
+    #     HMSG my-subject my-sid [my-reply-to] header_size total_size
+    #     NATS/1.0
+    #     My-Key: My-Value
+    #
+    #     My payload goes here
+    #
+    # The total size includes the headers, so the payload is
+    # `total_size - header_size` bytes long.
+    private def parse_message(buffer : Bytes, headers has_headers) : {Message, String}
+      line = read_line buffer
+
+      subject_bytes, cursor = next_token line, 0
+      sid_bytes, cursor = next_token line, cursor
+      third, cursor = next_token line, cursor
+      fourth, cursor = next_token line, cursor
+
+      if has_headers
+        fifth, cursor = next_token line, cursor
+        if fifth.empty? # No reply-to: HEADER_SIZE TOTAL_SIZE
+          reply_to_bytes = fifth
+          header_size = parse_int third
+          total_size = parse_int fourth
+        else # REPLY_TO HEADER_SIZE TOTAL_SIZE
+          reply_to_bytes = third
+          header_size = parse_int fourth
+          total_size = parse_int fifth
+        end
+        body_size = total_size - header_size
+      else
+        if fourth.empty? # No reply-to: PAYLOAD_SIZE
+          reply_to_bytes = fourth
+          body_size = parse_int third
+        else # REPLY_TO PAYLOAD_SIZE
+          reply_to_bytes = third
+          body_size = parse_int fourth
+        end
+      end
+
+      if subject_bytes.empty? || sid_bytes.empty? || body_size < 0
+        raise Error.new("Invalid message declaration: #{String.new(line).inspect}")
+      end
+
+      # These have to be copied out of the buffer before we read the headers,
+      # since reading the header block overwrites it.
+      subject = String.new(subject_bytes)
+      sid = String.new(sid_bytes)
+      reply_to = String.new(reply_to_bytes) unless reply_to_bytes.empty?
+
+      if has_headers
+        headers = read_headers buffer
+      end
+
+      body = @io.read_string(body_size)
+      expect_crlf
+
+      msg = Message.new subject, body,
+        reply_to: reply_to,
+        headers: headers
+
+      {msg, sid}
+    end
+
+    # Reads the header block of an `HMSG`, which is a `NATS/1.0` preamble
+    # followed by `Key: Value` lines and terminated by a blank line. Anything
+    # trailing the preamble is the request status, which we expose as the
+    # `Status` header.
+    private def read_headers(buffer : Bytes) : Headers
+      preamble = read_line buffer
+      unless preamble.size >= HEADER_PREAMBLE.bytesize && preamble[0, HEADER_PREAMBLE.bytesize] == HEADER_PREAMBLE.to_slice
+        raise Error.new("Invalid header declaration: #{String.new(preamble).inspect}")
+      end
+
+      headers = Headers.new
+      if preamble.size > HEADER_PREAMBLE.bytesize + 1
+        headers["Status"] = String.new(preamble[HEADER_PREAMBLE.bytesize + 1..])
+      end
+
+      until (line = read_line buffer).empty?
+        unless separator = line.index ':'.ord.to_u8!
+          raise Error.new("Invalid header line: #{String.new(line).inspect}")
+        end
+
+        value_start = separator + 1
+        while value_start < line.size && line[value_start] == ' '.ord
+          value_start += 1
+        end
+
+        headers.add intern(line[0, separator]), String.new(line[value_start..])
+      end
+
+      LOG.trace { "Headers: #{headers.inspect}" }
+
+      headers
+    end
+
+    # Returns the next space-delimited token in *line* starting at *cursor*,
+    # along with the cursor position just past it. An empty slice means the line
+    # held no more tokens.
+    private def next_token(line : Bytes, cursor : Int32) : {Bytes, Int32}
+      while cursor < line.size && line[cursor] == ' '.ord
+        cursor += 1
+      end
+
+      start = cursor
+      while cursor < line.size && line[cursor] != ' '.ord
+        cursor += 1
+      end
+
+      {line[start, cursor - start], cursor}
+    end
+
+    private def parse_int(bytes : Bytes) : Int32
+      return -1 if bytes.empty?
+
+      int = 0
+      bytes.each do |byte|
+        return -1 unless '0'.ord <= byte <= '9'.ord
+        int = (int * 10) + (byte - '0'.ord)
+      end
+
+      int
+    end
+
+    # Reads up to the next CRLF, returning the line without its terminator. The
+    # returned slice points into *buffer* (or into a larger heap-allocated
+    # buffer if the line didn't fit) and is only valid until the next read.
+    private def read_line(buffer : Bytes) : Bytes
+      size = 0
+
+      loop do
+        if peek = @io.peek
+          raise IO::EOFError.new if peek.empty?
+
+          if index = peek.index('\r'.ord.to_u8)
+            buffer = append buffer, size, peek[0, index]
+            size += index
+            @io.skip index + 1 # the line plus the CR
+            expect_lf
+            return buffer[0, size]
+          else
+            buffer = append buffer, size, peek
+            size += peek.size
+            @io.skip peek.size
+          end
+        else # The IO doesn't support peeking, so we go byte by byte
+          byte = @io.read_byte || raise IO::EOFError.new
+          if byte == '\r'.ord
+            expect_lf
+            return buffer[0, size]
+          end
+
+          buffer = grow buffer, size + 1
+          buffer[size] = byte
+          size += 1
+        end
+      end
+    end
+
+    private def append(buffer : Bytes, size : Int32, bytes : Bytes) : Bytes
+      return buffer if bytes.empty?
+
+      buffer = grow buffer, size + bytes.size
+      bytes.copy_to buffer[size, bytes.size]
+      buffer
+    end
+
+    private def grow(buffer : Bytes, needed : Int32) : Bytes
+      return buffer if needed <= buffer.size
+
+      larger = Bytes.new(Math.pw2ceil(needed))
+      buffer.copy_to larger[0, buffer.size]
+      larger
+    end
+
+    private def expect_crlf : Nil
+      unless @io.read_byte == '\r'.ord
+        raise Error.new("Expected CR")
+      end
+      expect_lf
+    end
+
+    private def expect_lf : Nil
+      unless @io.read_byte == '\n'.ord
+        raise Error.new("Expected LF")
+      end
+    end
+
+    # Header names come from a small, fixed vocabulary, so interning them avoids
+    # allocating the same handful of strings over and over. Note that the pool
+    # never evicts, so only low-cardinality values belong in here — subjects,
+    # SIDs, and reply-to subjects are all unbounded and must not be interned.
+    private def intern(bytes : Bytes) : String
+      STRING_POOL_MUTEX.synchronize { STRING_POOL.get bytes }
+    end
+  end
+end

--- a/src/log.cr
+++ b/src/log.cr
@@ -1,0 +1,5 @@
+require "log"
+
+module NATS
+  LOG = ::Log.for(self)
+end

--- a/src/nats.cr
+++ b/src/nats.cr
@@ -3,13 +3,16 @@ require "json"
 require "socket"
 require "uuid"
 require "openssl"
-require "log"
 
+require "./error"
 require "./message"
+require "./event_parser"
+require "./server_info"
 require "./headers"
 require "./nuid"
 require "./nkeys"
 require "./version"
+require "./log"
 
 # NATS is a pub/sub message bus.
 #
@@ -36,10 +39,6 @@ require "./version"
 module NATS
   alias Data = String | Bytes
 
-  # Generic error
-  class Error < ::Exception
-  end
-
   # Raised when trying to reply to a NATS message that is not a reply.
   class NotAReply < Error
     getter nats_message : Message
@@ -51,37 +50,6 @@ module NATS
 
   class ServerNotRespondingToPings < Error
   end
-
-  class UnknownCommand < Error
-  end
-
-  struct ServerInfo
-    include JSON::Serializable
-
-    getter server_id : String
-    getter server_name : String
-    getter version : String
-    getter go : String
-    getter host : String
-    getter port : Int32
-    getter? headers : Bool
-    getter max_payload : Int64
-    getter proto : Int32
-    getter? auth_required : Bool = false
-    getter? tls_required : Bool = false
-    getter? tls_verify : Bool = false
-    getter? tls_available : Bool = false
-    getter client_id : UInt64?
-    getter client_ip : String?
-    getter nonce : String?
-    getter cluster : String?
-    getter domain : String?
-    getter connect_urls : Array(String) { [] of String }
-    @[JSON::Field(key: "ldm")]
-    getter? lame_duck_mode : Bool = false
-  end
-
-  LOG = ::Log.for(self)
 
   # Instantiating a `NATS::Client` makes a connection to one of the given NATS
   # servers.
@@ -678,95 +646,19 @@ module NATS
           next
         end
 
-        line = @socket.read_line
         break if state.closed?
-        LOG.trace { line || "" }
-        case line
-        when .starts_with?("MSG"), .starts_with?("HMSG")
-          starting_point = 4 # "MSG "
-          has_headers = line.starts_with?('H')
-          starting_point += 1 if has_headers
-
-          if (subject_end = line.index(' ', starting_point)) && (sid_end = line.index(' ', subject_end + 1))
-            subject = line[starting_point...subject_end]
-            sid = line[subject_end + 1...sid_end].to_i
-
-            # Figure out if we got a reply_to and set it and bytesize accordingly
-            reply_to_with_byte_size = line[sid_end + 1..-1]
-            if has_headers # HMSG
-              # An HMSG event from the server looks like this (brackets imply optional):
-              #   HMSG my-subject my-sid [my-reply-to] header_size total_size
-              #   NATS/1.0
-              #   My-Key: My-Value
-              #
-              #   My Payload Goes Here
-              #
-              # Total size includes header size, so payload_size = total_size - header_size
-              if reply_to_boundary = reply_to_with_byte_size.index(' ')
-                # 3 tokens: REPLY_TO HEADER_SIZE TOTAL_SIZE
-                if header_length_boundary = reply_to_with_byte_size.index(' ', reply_to_boundary + 1)
-                  reply_to = reply_to_with_byte_size[0...reply_to_boundary]
-                  header_size = reply_to_with_byte_size[reply_to_boundary + 1...header_length_boundary].to_i
-                  bytesize = reply_to_with_byte_size[header_length_boundary + 1..-1].to_i - header_size
-                else # Only 2 tokens: HEADER_SIZE TOTAL_SIZE
-                  header_size = reply_to_with_byte_size[0...reply_to_boundary].to_i
-                  bytesize = reply_to_with_byte_size[reply_to_boundary + 1..-1].to_i - header_size
-                end
-              else
-                raise Error.new("Invalid message declaration with headers: #{line}")
-              end
-              headers = Message::Headers.new
-              # Headers preamble, intended to look like HTTP/1.1
-              if (header_decl = @socket.read_line).starts_with? "NATS/1.0"
-                # If there is anything beyond the NATS/1.0  status line, that
-                # indicates the request stauts and becomes the status header of
-                # the reply message.
-                if header_decl.size > "NATS/1.0 ".size
-                  headers["Status"] = header_decl["NATS/1.0 ".size..]
-                end
-                until (header_line = @socket.read_line).empty?
-                  key, value = header_line.split(/:\s*/, 2)
-                  headers.add key, value
-                end
-                LOG.trace { "Headers: #{headers.inspect}" }
-              else
-                raise Error.new("Invalid header declaration: #{header_decl} (msg: #{line})")
-              end
-            else # MSG
-              if boundary = reply_to_with_byte_size.rindex(' ')
-                reply_to = reply_to_with_byte_size[0...boundary]
-                bytesize = reply_to_with_byte_size[boundary + 1..-1].to_i
-              else
-                bytesize = reply_to_with_byte_size.to_i
-              end
-            end
-          else
-            raise Error.new("Invalid message declaration: #{line.inspect}")
-          end
-
-          body = @socket.read_string(bytesize)
-          @socket.skip 2 # CRLF
-
-          if subscription = @subscriptions[sid]?
-            subscription.send Message.new(subject, body, reply_to: reply_to, headers: headers) do |ex|
-              LOG.trace { "Error occurred in handling subscription #{sid}: #{ex}" }
-              @on_error.call ex
-            end
-            if subscription.messages_remaining
-              LOG.trace { "Messages remaining in subscription #{sid} to #{subscription.subject}: #{subscription.messages_remaining}" }
-            end
-            if (messages_remaining = subscription.messages_remaining) && messages_remaining <= 0
-              @subscriptions.delete sid
-              subscription.close
-            end
-          else
-            LOG.debug { "No subscription #{sid}" }
-          end
-        when "+OK"
+        # The parser is a struct wrapping the socket, so building one per event
+        # costs nothing and — unlike hoisting it out of the loop — picks up the
+        # new socket after a reconnect.
+        event = EventParser.new(@socket).call
+        case event
+        in Protocol::MessageEvent
+          deliver event.message, to: event.sid
+        in Protocol::OKEvent
           # Cool, thanks
-        when "PING"
+        in Protocol::PingEvent
           pong
-        when "PONG"
+        in Protocol::PongEvent
           if @ping_count.sub(1) >= 0
             select
             when ping = @pings.receive
@@ -776,17 +668,22 @@ module NATS
           else
             raise Error.new("Received PONG without sending a PING")
           end
-        when .starts_with? "INFO"
-          @server_info = ServerInfo.from_json line[5..-1]
+        in Protocol::InfoEvent
+          @server_info = event.server_info
           if (urls = @server_info.connect_urls).any?
             @servers = urls.map do |host_with_port| # it's not a real URL :-(
               URI.parse("nats://#{host_with_port}")
             end
           end
-        when .starts_with? "-ERR"
-          @on_error.call Error.new(line)
-        else
-          @on_error.call UnknownCommand.new(line)
+        in Protocol::ErrorEvent, Protocol::UnknownEvent
+          @on_error.call event.error
+        in Protocol::Event
+          # Unreachable — `Event` is abstract. Crystal collapses the union of
+          # its subclasses back into the virtual type, though, so exhaustiveness
+          # demands a branch for the base itself. It also means a newly added
+          # event type lands here rather than failing to compile, so route it to
+          # the error handler instead of letting it disappear.
+          @on_error.call UnknownCommand.new("Unhandled protocol event: #{event.type}")
         end
         backoff = 1.millisecond
         Fiber.yield
@@ -797,6 +694,28 @@ module NATS
       end
     ensure
       LOG.warn { "Exited inbound message loop" }
+    end
+
+    # The wire protocol carries SIDs as opaque tokens, but we only ever hand the
+    # server the integer SIDs we generate ourselves, so anything else is a
+    # subscription we don't know about.
+    private def deliver(msg : Message, to sid : String) : Nil
+      unless (id = sid.to_i64?) && (subscription = @subscriptions[id]?)
+        LOG.debug { "No subscription #{sid}" }
+        return
+      end
+
+      subscription.send msg do |ex|
+        LOG.trace { "Error occurred in handling subscription #{sid}: #{ex}" }
+        @on_error.call ex
+      end
+      if subscription.messages_remaining
+        LOG.trace { "Messages remaining in subscription #{sid} to #{subscription.subject}: #{subscription.messages_remaining}" }
+      end
+      if (messages_remaining = subscription.messages_remaining) && messages_remaining <= 0
+        @subscriptions.delete id
+        subscription.close
+      end
     end
 
     private def handle_inbound_disconnect(exception, backoff : Time::Span)

--- a/src/server_info.cr
+++ b/src/server_info.cr
@@ -1,0 +1,29 @@
+require "json"
+
+module NATS
+  struct ServerInfo
+    include JSON::Serializable
+
+    getter server_id : String
+    getter server_name : String
+    getter version : String
+    getter go : String
+    getter host : String
+    getter port : Int32
+    getter? headers : Bool
+    getter max_payload : Int64
+    getter proto : Int32
+    getter? auth_required : Bool = false
+    getter? tls_required : Bool = false
+    getter? tls_verify : Bool = false
+    getter? tls_available : Bool = false
+    getter client_id : UInt64?
+    getter client_ip : String?
+    getter nonce : String?
+    getter cluster : String?
+    getter domain : String?
+    getter connect_urls : Array(String) { [] of String }
+    @[JSON::Field(key: "ldm")]
+    getter? lame_duck_mode : Bool = false
+  end
+end


### PR DESCRIPTION
This PR extracts the meat of the `begin_inbound_loop` method to an `EventParser`. Rather than chopping up strings and creating a bunch of intermediate heap allocations, the `EventParser` instead parses the tokens straight off the wire, only allocating what we need to allocate and making the inbound loop method easier to reason about. That method's been pretty rough to understand for years now and I've been wanting to clean it up.

Admittedly, the `EventParser` isn't easy to reason about. It still needs some love. But at least it's sequestered now and not clogging up the main inbound loop code.